### PR TITLE
 chore(sway): allow separate outputs config

### DIFF
--- a/dotfiles/sway/config
+++ b/dotfiles/sway/config
@@ -31,14 +31,14 @@ output * bg '$HOME/.local/share/backgrounds/2025-05-Trondheim-02744_16_9.jpg' fi
 #
 # You can get the names of your outputs by running: swaymsg -t get_outputs
 
-output eDP-1 resolution 1920x1080@60Hz position 0,0
+# output eDP-1 resolution 1920x1080@60Hz position 0,0
 # output DP-2 resolution 3840x2160@59.997Hz position 1920,0
 # output DP-2 resolution 2560x1440@99.946Hz position 3100,1
 # output DP-1 resolution 3840x2160@59.997Hz position 1920,0
-output DP-1 resolution 3840x2160@59.997Hz position 3100,0
+# output DP-1 resolution 3840x2160@59.997Hz position 3100,0
 
 # HDMI output configuration
-output HDMI-A-1 resolution 2560x1440@120.049Hz position 1940,0 adaptive_sync on
+# output HDMI-A-1 resolution 2560x1440@120.049Hz position 1940,0 adaptive_sync on
 
 # config for the other monitor
 #output DP-3 resolution 2560x1440@59.940Hz position 1930,0 adaptive_sync on

--- a/dotfiles/sway_output/outputs
+++ b/dotfiles/sway_output/outputs
@@ -1,3 +1,9 @@
+output eDP-1 resolution 1920x1080@60Hz position 0,0
+output DP-1 resolution 3840x2160@59.997Hz position 1920,0
+
+# HDMI output configuration
+output HDMI-A-1 resolution 2560x1440@120.049Hz position 1940,0 adaptive_sync on
+
 set $output-primary DP-1
 set $output-secondary eDP-1
 

--- a/home-p14s.nix
+++ b/home-p14s.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  home.file = {
+    ".config/sway/config.d/outputs".source = ./p14s/outputs;
+  };
+
+  imports = [
+    ./home.nix
+  ];
+}

--- a/non-nix.nix
+++ b/non-nix.nix
@@ -6,6 +6,11 @@
 }:
 
 {
+
+  home.file = {
+    ".config/sway/config.d/outputs".source = ./dotfiles/sway_output/outputs;
+  };
+
   imports = [
     ./gpu/nixgl.nix
   ];

--- a/p14s/outputs
+++ b/p14s/outputs
@@ -1,0 +1,22 @@
+output eDP-1 resolution 3072x1920@60Hz position 0,0 scale 1.5 adaptive_sync on
+output DP-1 resolution 3840x2160@59.997Hz position 3100,0
+
+# HDMI output configuration
+output HDMI-A-1 resolution 2560x1440@120.049Hz position 1940,0 adaptive_sync on
+
+set $output-primary DP-1
+set $output-secondary eDP-1
+
+# workspace to displays
+workspace 1 output $output-secondary
+workspace 3 output $output-secondary
+workspace 5 output $output-secondary
+workspace 7 output $output-secondary
+workspace 9 output $output-secondary
+
+workspace 2 output $output-primary
+workspace 4 output $output-primary
+workspace 6 output $output-primary
+workspace 8 output $output-primary
+workspace 10 output $output-primary
+

--- a/wayland/window_manager_sway.nix
+++ b/wayland/window_manager_sway.nix
@@ -6,8 +6,17 @@
 }:
 
 {
+  # disable sway config generation until migrated
+  xdg.configFile."sway/config".enable = false;
+
   home.file = {
-    ".config/sway".source = ../dotfiles/sway;
+    ".config/sway/config".source = ../dotfiles/sway/config;
+    ".config/sway/catppuccin-macchiato".source = ../dotfiles/sway/catppuccin-macchiato;
+    ".config/sway/lock.sh".source = ../dotfiles/sway/lock.sh;
+    ".config/sway/config.d/application_defaults".source = ../dotfiles/sway/config.d/application_defaults;
+    ".config/sway/config.d/autostart_applications".source = ../dotfiles/sway/config.d/autostart_applications;
+    ".config/sway/config.d/theme".source = ../dotfiles/sway/config.d/theme;
+    ".config/sway/config.d/xdg-desktop-portal".source = ../dotfiles/sway/config.d/xdg-desktop-portal;
     ".local/share/backgrounds/Toronto.jpg".source = ../assets/backgrounds/Toronto.jpg;
     ".local/share/backgrounds/2025-05-Trondheim-02744.jpg".source =
       ../assets/backgrounds/2025-05-Trondheim-02744.jpg;


### PR DESCRIPTION
This PR introduces the host specific home configuration, it might be used e.g. for the separte display configuration as shown in home-p14s.nix